### PR TITLE
HPCC-11338 Use control:alive for Roxie check

### DIFF
--- a/utils/check_roxie/check_roxie
+++ b/utils/check_roxie/check_roxie
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-OUTPUT=`testsocket $1 "<control:metrics/>" |grep Status |grep ok -c`
+OUTPUT=`testsocket $1 "<control:alive/>" |grep Status |grep ok -c`
 
 if [ "$OUTPUT" -eq "1" ]; then
     echo "OK"


### PR DESCRIPTION
Replace control:metrics with control:alive when checking Roxie health.
