### PR TITLE
HPCC-12974 Fix nagios build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ MESSAGE (HPCC_SOURCE_DIR: ${HPCC_SOURCE_DIR})
 
 SET(CPACK_PACKAGE_VERSION_MAJOR ${majorver})
 SET(CPACK_PACKAGE_VERSION_MINOR ${minorver})
-SET(CPACK_PACKAGE_VERSION_PATCH ${point}${stagever})
+SET(CPACK_PACKAGE_VERSION_PATCH ${point}-${stagever})
 
 
 set (CPACK_PACKAGE_CONTACT "HPCCSystems <ossdevelopment@lexisnexis.com>")

--- a/cmake_modules/dependencies/el5.cmake.in
+++ b/cmake_modules/dependencies/el5.cmake.in
@@ -1,1 +1,1 @@
-set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform >= ${HPCC_MAJOR}.${HPCC_MINOR}.${HPCC_POINT}-${HPCC_SEQUENCE}", "nagios3" )
+set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform >= ${HPCC_MAJOR}.${HPCC_MINOR}.${HPCC_POINT}-${HPCC_SEQUENCE}, nagios3" )


### PR DESCRIPTION
HPCC-12974 Nagios monitoring build issues on centos5

	- Fix naming convention to be consistent with platform
	- Fix centos 5 build

Signed-off-by: gleb.aronsky <gleb.aronsky@lexisnexis.com>