### PR TITLE
HPCC-13153 Nagios - add missing cfg file to package

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -22,3 +22,4 @@
 #    CMake for hpcc nagios and nrpe config
 #####################################################
 INSTALL(FILES hpcc_nrpe.cfg DESTINATION   /etc/nagios/nrpe.d/)
+INSTALL(FILES hpcc_nagios.cfg DESTINATION /etc/nagios3/conf.d/)


### PR DESCRIPTION
	- Include hpcc_nagios.cfg that defines the check utilities in the package

Signed-off-by: Gleb Aronsky <gleb.aronsky@lexisnexis.com>