### PR TITLE
HPCC-15038 nagios-monitoring fails installation do conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ set (CPACK_RPM_PACKAGE_VERSION "${version}" )
 set (CPACK_RPM_PACKAGE_RELEASE "${stagever}")
 
 # Fix filesystem conflict error, This fix requires cmake 3+
-SET(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/etc/nagios;/etc/nagios/conf.d;/etc/nrpe.d;/usr/lib64/nagios" )
+SET(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/etc/nagios;/etc/nagios/conf.d;/etc/nrpe.d;/usr/lib64/nagios;/usr/lib64/nagios/plugins" )
 
 MESSAGE ( "CPACK_RPM_PACKAGE_ARCHITECTURE ${CPACK_RPM_PACKAGE_ARCHITECTURE}" )
 MESSAGE ( "CPACK_SYSTEM_NAME ${CPACK_SYSTEM_NAME}" )


### PR DESCRIPTION
        - Add /usr/lib64/nagios/plugins to cmake
          CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION

Signed-off-by: Gleb Aronsky <gleb.aronsky@lexisnexis.com>