### PR TITLE
HPCC-19715  Include sacmd.cpp in the check_sasha source

### DIFF
--- a/utils/check_sasha/CMakeLists.txt
+++ b/utils/check_sasha/CMakeLists.txt
@@ -26,6 +26,7 @@ project( check_sasha )
 
 set (   SRCS
         main.cpp
+        ${HPCC_SOURCE_DIR}/dali/sasha/sacmd.cpp
     )
 
 include_directories (


### PR DESCRIPTION
The main.cpp of check_sasha reference createSashcommand. It includes sacmd.hpp but the function declared and defined in sacmd.cpp

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com>
@Michael-Gardner, please review it.