### PR TITLE
HPCC-21741  Add include dir for rmtfile.hpp

### DIFF
--- a/utils/check_dafilesrv/CMakeLists.txt
+++ b/utils/check_dafilesrv/CMakeLists.txt
@@ -33,6 +33,7 @@ include_directories (
 	${HPCC_SOURCE_DIR}/common/remote
         ${HPCC_SOURCE_DIR}/system/jlib
         ${HPCC_SOURCE_DIR}/system/include
+        ${HPCC_SOURCE_DIR}/fs/dafsclient
         ${CMAKE_BINARY_DIR}
         ${CMAKE_BINARY_DIR}/oss
     )


### PR DESCRIPTION
Add the new include directory for rmtfile.hpp

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 

@gfortil please review.