### PR TITLE
HPCC-24333 Skip shebang process on RPM packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,9 @@ if(CMAKE_SYSTEM MATCHES Linux)
         ###
         ## CPack instruction required for RPM
         ###
+	set(CPACK_RPM_SPEC_MORE_DEFINE
+          "%undefine __brp_mangle_shebangs"
+	)
         message("-- Will build RPM package")
         message("-- Packing BASH installation files")
         set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_BINARY_DIR}/postinst")


### PR DESCRIPTION
 Work-around  for  ambiguous python  reported by CentOS 8

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexis.com>

@rpastrana please review